### PR TITLE
Expand time before being inactive in chat

### DIFF
--- a/chat/room.html
+++ b/chat/room.html
@@ -117,11 +117,11 @@ $textarea
 	}
 	function active() {
 		clearTimeout(timeout);
-		timeout = setTimeout(inactive, 10000);
+		timeout = setTimeout(inactive, 120000);
 		statechange(1);
 	}
 	if (ta) {
-		var timeout = setTimeout(inactive, 10000);
+		var timeout = setTimeout(inactive, 120000);
 		addEventListener('keyup', active);
 		addEventListener('keydown', active);
 		addEventListener('click', active);


### PR DESCRIPTION
Currently it only takes 10 seconds before you are considered inactive.
That is way too short. This commit changes it into two minutes.
