### PR TITLE
Don't play a sound for your own message

### DIFF
--- a/chat/room.html
+++ b/chat/room.html
@@ -198,9 +198,7 @@ $textarea
 				if (!lock || !document.getElementById(hash)) cont.scrollTop += div.offsetHeight + 3;
 			} else cont.appendChild(div);
 			if (data.event == 'add') {
-				if (username != data.user) {
-					audio.play();
-				}
+				if (username != data.user) audio.play();
 				if (onBottom) cont.scrollTop = cont.scrollHeight;
 			}
 			cont.onscroll();


### PR DESCRIPTION
When you post a message yourself, you also hear the sound notification,
which is not necessary. This commit makes sure that you don't hear a sound
when you post a message yourself.
